### PR TITLE
Unify color scheme

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -342,8 +342,8 @@ body {
 .api-controls input:focus,
 .api-controls select:focus {
   outline: none;
-  border-color: #3498db;
-  box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.2), 0 2px 8px rgba(0, 0, 0, 0.15);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.2), 0 2px 8px rgba(0, 0, 0, 0.15);
   transform: translateY(-1px);
 }
 
@@ -362,7 +362,7 @@ body {
   padding: 6px 14px;
   border-radius: 6px;
   border: none;
-  background: linear-gradient(135deg, #3498db 0%, #2980b9 100%);
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-hover) 100%);
   color: white;
   cursor: pointer;
   font-size: 12px;
@@ -371,13 +371,13 @@ body {
   min-height: 32px;
   height: 32px;
   white-space: nowrap;
-  box-shadow: 0 2px 6px rgba(52, 152, 219, 0.3);
+  box-shadow: 0 2px 6px rgba(79, 70, 229, 0.3);
   text-transform: uppercase;
   letter-spacing: 0.3px;
 }
 
 .api-controls button.active {
-  background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+  background: linear-gradient(135deg, var(--color-danger) 0%, var(--color-danger) 100%);
   box-shadow: 0 2px 6px rgba(231, 76, 60, 0.4);
   animation: pulse 2s infinite;
 }
@@ -398,18 +398,18 @@ body {
 }
 
 .api-controls button:hover:not(:disabled) {
-  background: linear-gradient(135deg, #2980b9 0%, #1f5f8b 100%);
+  background: linear-gradient(135deg, var(--color-primary-hover) 0%, var(--color-primary-hover) 100%);
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(52, 152, 219, 0.4);
+  box-shadow: 0 4px 12px rgba(79, 70, 229, 0.4);
 }
 
 .api-controls button.active:hover {
-  background: linear-gradient(135deg, #c0392b 0%, #a93226 100%);
-  box-shadow: 0 4px 12px rgba(231, 76, 60, 0.5);
+  background: linear-gradient(135deg, var(--color-danger) 0%, var(--color-danger) 100%);
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.5);
 }
 
 .api-controls button:disabled {
-  background: linear-gradient(135deg, #95a5a6 0%, #7f8c8d 100%);
+  background: linear-gradient(135deg, var(--color-muted) 0%, var(--color-muted) 100%);
   cursor: not-allowed;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   transform: none;
@@ -512,7 +512,7 @@ body {
 }
 
 .message-item.user {
-  background-color: #007bff;
+  background-color: var(--color-primary);
   color: white;
   align-self: flex-end;
   border-bottom-right-radius: 4px;
@@ -543,7 +543,7 @@ body {
   justify-content: center;
   padding: 40px 20px;
   text-align: center;
-  background-color: #f8f9fa;
+  background-color: var(--color-light);
   flex: 1;
 }
 
@@ -579,7 +579,7 @@ body {
 }
 
 .no-active-chat button {
-  background-color: #007bff;
+  background-color: var(--color-primary);
   color: white;
   border: none;
   padding: 12px 24px;
@@ -600,7 +600,7 @@ body {
 }
 
 .no-active-chat button:hover {
-  background-color: #0056b3;
+  background-color: var(--color-primary-hover);
 }
 
 /* Loading states */
@@ -704,8 +704,8 @@ body {
   margin-bottom: 12px;
   border-radius: 8px;
   overflow: hidden;
-  border: 1px solid #e0e0e0;
-  background: #f8f9fa;
+  border: 1px solid var(--color-border);
+  background: var(--color-light);
 }
 
 .media-preview img,
@@ -745,8 +745,8 @@ body {
 
 /* Camera capture container styles */
 .camera-capture-container {
-  background: #f8f9fa;
-  border: 1px solid #e0e0e0;
+  background: var(--color-light);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
   padding: 16px;
   margin-bottom: 12px;
@@ -892,7 +892,7 @@ body {
   width: 16px;
   height: 16px;
   border: 2px solid #f3f3f3;
-  border-top: 2px solid #3498db;
+  border-top: 2px solid var(--color-primary);
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }
@@ -1071,8 +1071,8 @@ body {
     flex: 1;
   justify-content: center;
     min-height: 44px;
-    border: 1px solid #dadce0;
-    background: #f8f9fa;
+    border: 1px solid var(--color-border);
+    background: var(--color-light);
   }
   
   .action-button span {
@@ -1207,7 +1207,7 @@ body {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   border: 1px solid rgba(255, 255, 255, 0.2);
   backdrop-filter: blur(10px);
-  background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+  background: linear-gradient(135deg, var(--color-danger) 0%, var(--color-danger) 100%);
   color: white;
   animation: livePulse 2s infinite;
 }
@@ -1263,8 +1263,8 @@ body {
 }
 
 .api-controls select.provider-select:hover {
-  border-color: #3498db;
-  box-shadow: 0 2px 6px rgba(52, 152, 219, 0.2);
+  border-color: var(--color-primary);
+  box-shadow: 0 2px 6px rgba(79, 70, 229, 0.2);
 }
 
 .api-controls input.api-key-input {
@@ -1296,19 +1296,19 @@ body {
 }
 
 .action-button.live-button {
-  border: 1px solid #dadce0;
+  border: 1px solid var(--color-border);
 }
 
 .action-button.live-button.active {
-  background: #ea4335;
+  background: var(--color-danger);
   color: white;
-  border-color: #ea4335;
+  border-color: var(--color-danger);
 }
 
 .action-button.live-button.active:hover:not(:disabled) {
-  background: #d73527;
+  background: var(--color-danger);
   color: white;
-  border-color: #d73527;
+  border-color: var(--color-danger);
 }
 
 /* Sidebar API Controls */
@@ -1355,9 +1355,9 @@ body {
 .sidebar-select:focus,
 .sidebar-input:focus {
   outline: none;
-  border-color: #3498db;
+  border-color: var(--color-primary);
   background: rgba(255, 255, 255, 0.15);
-  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.2);
 }
 
 .sidebar-input::placeholder {
@@ -1485,7 +1485,7 @@ body {
   justify-content: center;
   flex: 1;
   height: calc(100vh - 56px); /* Account for header height */
-  background-color: #f8f9fa;
+  background-color: var(--color-light);
 }
 
 .auth-loading-content,

--- a/frontend/src/components/GeminiLiveDirect.css
+++ b/frontend/src/components/GeminiLiveDirect.css
@@ -34,7 +34,7 @@
   align-items: center;
   margin-bottom: 20px;
   padding-bottom: 15px;
-  border-bottom: 2px solid #e0e0e0;
+  border-bottom: 2px solid var(--color-border);
   flex-shrink: 0; /* Don't shrink header */
 }
 
@@ -182,18 +182,18 @@
 }
 
 .status.connecting {
-  background: #fff3e0;
-  color: #f57c00;
+  background: var(--color-warning-bg, #fff7ed);
+  color: var(--color-warning, #f59e0b);
 }
 
 .status.connected {
-  background: #e8f5e8;
-  color: #388e3c;
+  background: var(--color-success-bg, #ecfdf5);
+  color: var(--color-success, #10b981);
 }
 
 .status.disconnected {
-  background: #f5f5f5;
-  color: #666;
+  background: var(--color-light);
+  color: var(--color-muted);
 }
 
 /* Video Preview */
@@ -252,18 +252,18 @@
 .text-input {
   flex: 1;
   padding: 12px 18px;
-  border: 2px solid #e5e5e7;
+  border: 2px solid var(--color-border);
   border-radius: 24px;
   font-size: 15px;
   outline: none;
   transition: all 0.2s ease;
-  background: #f8f9fa;
+  background: var(--color-light);
   height: 44px;
   min-width: 0;
 }
 
 .text-input:focus {
-  border-color: #007aff;
+  border-color: var(--color-primary);
   background: white;
   box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.1);
 }
@@ -273,7 +273,7 @@
   height: 44px;
   border: none;
   border-radius: 50%;
-  background: #007aff;
+  background: var(--color-primary);
   color: white;
   font-size: 18px;
   font-weight: bold;
@@ -286,12 +286,12 @@
 }
 
 .send-btn:hover:not(:disabled) {
-  background: #0056cc;
+  background: var(--color-primary-hover);
   transform: scale(1.05);
 }
 
 .send-btn:disabled {
-  background: #c7c7cc;
+  background: var(--color-border);
   cursor: not-allowed;
   transform: none;
 }
@@ -310,7 +310,7 @@
   height: 60px;
   border: none;
   border-radius: 50%;
-  background: #f2f2f7;
+  background: var(--color-light);
   font-size: 24px;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -321,7 +321,7 @@
 }
 
 .control-btn:hover:not(:disabled) {
-  background: #e5e5ea;
+  background: var(--color-sidebar-hover);
   transform: scale(1.05);
 }
 
@@ -332,32 +332,32 @@
 }
 
 .control-btn.active {
-  background: #007aff;
+  background: var(--color-primary);
   color: white;
-  border-color: #0056cc;
+  border-color: var(--color-primary-hover);
 }
 
 .control-btn.active:hover {
-  background: #0056cc;
+  background: var(--color-primary-hover);
 }
 
 /* Specific button styles */
 .connect-btn {
-  background: #34c759;
+  background: var(--color-success);
   color: white;
 }
 
 .connect-btn:hover {
-  background: #28a745;
+  background: var(--color-success);
 }
 
 .disconnect-btn {
-  background: #ff3b30;
+  background: var(--color-danger);
   color: white;
 }
 
 .disconnect-btn:hover {
-  background: #d70015;
+  background: var(--color-danger);
 }
 
 /* Voice Selector Container */
@@ -366,12 +366,12 @@
 }
 
 .voice-btn {
-  background: #ff9500;
+  background: var(--color-warning);
   color: white;
 }
 
 .voice-btn:hover {
-  background: #e6850e;
+  background: var(--color-warning);
 }
 
 .voice-menu {
@@ -382,7 +382,7 @@
   border-radius: 12px;
   padding: 16px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-  border: 1px solid #e5e5e7;
+  border: 1px solid var(--color-border);
   min-width: 200px;
   z-index: 1000;
   opacity: 0;
@@ -409,14 +409,14 @@
   display: block;
   font-size: 14px;
   font-weight: 600;
-  color: #333;
+  color: var(--color-text);
   margin-bottom: 6px;
 }
 
 .voice-option-group select {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #e5e5e7;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   font-size: 14px;
   background: white;
@@ -425,7 +425,7 @@
 }
 
 .voice-option-group select:focus {
-  border-color: #007aff;
+  border-color: var(--color-primary);
 }
 
 /* Mobile Responsive */
@@ -498,17 +498,17 @@
 }
 
 .messages::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: var(--color-light);
   border-radius: 3px;
 }
 
 .messages::-webkit-scrollbar-thumb {
-  background: #c1c1c1;
+  background: var(--color-border);
   border-radius: 3px;
 }
 
 .messages::-webkit-scrollbar-thumb:hover {
-  background: #a1a1a1;
+  background: var(--color-muted);
 }
 
 /* Touch improvements for mobile */

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -1,15 +1,20 @@
 :root {
-  --color-bg: #f4f4f4;
-  --color-text: #333;
-  --color-muted: #666;
-  --color-primary: #1a73e8;
-  --color-secondary: #5e1f60;
-  --color-secondary-hover: #732c75;
-  --color-light: #f8f9fa;
-  --color-border: #e5e5e7;
-  --color-sidebar-bg: #2c3e50;
-  --color-sidebar-highlight: #e8f0fe;
-  --color-sidebar-hover: #f1f3f4;
+  /* Light theme */
+  --color-bg: #f8fafc;
+  --color-text: #111827;
+  --color-muted: #6b7280;
+  --color-primary: #4f46e5;
+  --color-primary-hover: #4338ca;
+  --color-secondary: #14b8a6;
+  --color-secondary-hover: #0d9488;
+  --color-success: #10b981;
+  --color-danger: #ef4444;
+  --color-warning: #f59e0b;
+  --color-light: #ffffff;
+  --color-border: #d1d5db;
+  --color-sidebar-bg: #0f172a;
+  --color-sidebar-highlight: #e2e8f0;
+  --color-sidebar-hover: #f1f5f9;
 
   --radius-pill: 24px;
   --radius-md: 8px;
@@ -29,16 +34,21 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-bg: #1f2937;
-    --color-text: #f9fafb;
-    --color-muted: #9ca3af;
-    --color-primary: #60a5fa;
-    --color-secondary: #b747d1;
-    --color-secondary-hover: #a230c0;
-    --color-light: #374151;
-    --color-border: #374151;
+    /* Dark theme */
+    --color-bg: #0f172a;
+    --color-text: #f8fafc;
+    --color-muted: #94a3b8;
+    --color-primary: #6366f1;
+    --color-primary-hover: #4f46e5;
+    --color-secondary: #2dd4bf;
+    --color-secondary-hover: #14b8a6;
+    --color-success: #34d399;
+    --color-danger: #f87171;
+    --color-warning: #fbbf24;
+    --color-light: #1e293b;
+    --color-border: #334155;
     --color-sidebar-bg: #111827;
-    --color-sidebar-highlight: #374151;
+    --color-sidebar-highlight: #1e293b;
     --color-sidebar-hover: #1f2937;
   }
 }


### PR DESCRIPTION
## Summary
- add new modern palette in design tokens
- use color variables in GeminiLiveDirect and App styles

## Testing
- `python backend/run_tests.py` *(fails: ModuleNotFoundError)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841f237f004832384610bd534fdd2d4