### PR TITLE
Unify color palette

### DIFF
--- a/frontend/src/components/AppHeader.css
+++ b/frontend/src/components/AppHeader.css
@@ -4,8 +4,8 @@
   left: 0;
   right: 0;
   height: 56px; /* Use consistent mobile height for all screen sizes */
-  background: #ffffff;
-  border-bottom: 1px solid #e0e0e0;
+  background: var(--color-light);
+  border-bottom: 1px solid var(--color-border);
   z-index: 1100;
   display: flex;
   align-items: center;
@@ -43,7 +43,7 @@
   padding: 8px;
   cursor: pointer;
   border-radius: 8px;
-  color: #5f6368;
+  color: var(--color-muted);
   transition: all 0.2s ease;
   min-width: 44px;
   min-height: 44px;
@@ -52,17 +52,17 @@
 }
 
 .mobile-menu-button:hover {
-  background-color: #f1f3f4;
-  color: #202124;
+  background-color: var(--color-sidebar-hover);
+  color: var(--color-text);
 }
 
 .mobile-menu-button:active {
-  background-color: #e8eaed;
+  background-color: var(--color-sidebar-highlight);
 }
 
 .mobile-menu-button.sidebar-open {
-  background-color: #e8f0fe;
-  color: #1a73e8;
+  background-color: var(--color-sidebar-highlight);
+  color: var(--color-primary);
 }
 
 /* App title */
@@ -75,7 +75,7 @@
 .app-name {
   font-size: 18px; /* Use mobile font size for all screen sizes */
   font-weight: 600;
-  color: #202124;
+  color: var(--color-text);
   letter-spacing: -0.5px;
 }
 
@@ -84,7 +84,7 @@
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: #f1f3f4;
+  background: var(--color-sidebar-hover);
   /* This will be hidden for now but provides space for future user menu */
   opacity: 0;
 }

--- a/frontend/src/components/AuthWidget.css
+++ b/frontend/src/components/AuthWidget.css
@@ -18,8 +18,8 @@
 .loading-spinner {
   width: 16px;
   height: 16px;
-  border: 2px solid #e5e7eb;
-  border-top: 2px solid #3b82f6;
+  border: 2px solid var(--color-border);
+  border-top: 2px solid var(--color-primary);
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }
@@ -49,24 +49,25 @@
 }
 
 .signup-button {
-  color: #6b7280;
-  border-color: #d1d5db;
+  color: var(--color-muted);
+  border-color: var(--color-border);
 }
 
 .signup-button:hover {
-  background-color: #f9fafb;
-  border-color: #9ca3af;
+  background-color: var(--color-light);
+  border-color: var(--color-muted);
 }
 
 .login-button {
-  background-color: #000;
-  color: #fff;
-  border-color: #000;
+  background-color: var(--color-primary);
+  color: var(--color-light);
+  border-color: var(--color-primary);
 }
 
 .login-button:hover {
-  background-color: #1f2937;
-  border-color: #1f2937;
+  background-color: var(--color-primary);
+  opacity: 0.9;
+  border-color: var(--color-primary);
 }
 
 /* User Avatar (Logged In) */
@@ -74,7 +75,7 @@
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background-color: #3b82f6;
+  background-color: var(--color-primary);
   border: none;
   cursor: pointer;
   display: flex;
@@ -85,7 +86,7 @@
 }
 
 .user-avatar:hover {
-  background-color: #2563eb;
+  background-color: var(--color-secondary-hover);
   transform: scale(1.05);
 }
 
@@ -102,8 +103,8 @@
   top: 100%;
   right: 0;
   margin-top: 8px;
-  background: white;
-  border: 1px solid #e5e7eb;
+  background: var(--color-light);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
   min-width: 220px;
@@ -114,25 +115,25 @@
 /* User Info Section */
 .user-info {
   padding: 12px 16px;
-  border-bottom: 1px solid #f3f4f6;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .user-name {
   font-size: 14px;
   font-weight: 600;
-  color: #111827;
+  color: var(--color-text);
   margin-bottom: 2px;
 }
 
 .user-email {
   font-size: 12px;
-  color: #6b7280;
+  color: var(--color-muted);
 }
 
 /* Dropdown Divider */
 .dropdown-divider {
   height: 1px;
-  background-color: #f3f4f6;
+  background-color: var(--color-border);
 }
 
 /* Dropdown Items */
@@ -147,12 +148,12 @@
   align-items: center;
   gap: 8px;
   font-size: 14px;
-  color: #374151;
+  color: var(--color-text);
   transition: background-color 0.2s ease;
 }
 
 .dropdown-item:hover {
-  background-color: #f9fafb;
+  background-color: var(--color-sidebar-hover);
 }
 
 .logout-button {
@@ -166,57 +167,58 @@
 /* Dark mode support */
 @media (prefers-color-scheme: dark) {
   .auth-button {
-    color: #d1d5db;
+    color: var(--color-muted);
   }
   
   .signup-button {
-    color: #9ca3af;
-    border-color: #4b5563;
+    color: var(--color-muted);
+    border-color: var(--color-border);
   }
   
   .signup-button:hover {
-    background-color: #1f2937;
-    border-color: #6b7280;
+    background-color: var(--color-bg);
+    border-color: var(--color-muted);
   }
   
   .login-button {
-    background-color: #fff;
-    color: #000;
-    border-color: #fff;
+    background-color: var(--color-primary);
+    color: var(--color-light);
+    border-color: var(--color-primary);
   }
   
   .login-button:hover {
-    background-color: #f3f4f6;
-    border-color: #f3f4f6;
+    background-color: var(--color-primary);
+    opacity: 0.9;
+    border-color: var(--color-primary);
   }
   
   .user-dropdown {
-    background: #1f2937;
-    border-color: #374151;
+    background: var(--color-bg);
+    border-color: var(--color-border);
   }
   
   .user-info {
-    border-bottom-color: #374151;
+    border-bottom-color: var(--color-border);
   }
   
   .user-name {
-    color: #f9fafb;
+    color: var(--color-text);
   }
   
   .user-email {
-    color: #9ca3af;
+    color: var(--color-muted);
   }
   
   .dropdown-divider {
-    background-color: #374151;
+    background-color: var(--color-border);
   }
   
   .dropdown-item {
-    color: #d1d5db;
+    color: var(--color-text);
   }
   
   .dropdown-item:hover {
-    background-color: #374151;
+    background-color: var(--color-sidebar-hover);
   }
   
   .logout-button {

--- a/frontend/src/components/GeminiLiveDirect.css
+++ b/frontend/src/components/GeminiLiveDirect.css
@@ -34,7 +34,7 @@
   align-items: center;
   margin-bottom: 20px;
   padding-bottom: 15px;
-  border-bottom: 2px solid #e0e0e0;
+  border-bottom: 2px solid var(--color-border);
   flex-shrink: 0; /* Don't shrink header */
 }
 
@@ -192,8 +192,8 @@
 }
 
 .status.disconnected {
-  background: #f5f5f5;
-  color: #666;
+  background: var(--color-light);
+  color: var(--color-muted);
 }
 
 /* Video Preview */
@@ -252,18 +252,18 @@
 .text-input {
   flex: 1;
   padding: 12px 18px;
-  border: 2px solid #e5e5e7;
+  border: 2px solid var(--color-border);
   border-radius: 24px;
   font-size: 15px;
   outline: none;
   transition: all 0.2s ease;
-  background: #f8f9fa;
+  background: var(--color-light);
   height: 44px;
   min-width: 0;
 }
 
 .text-input:focus {
-  border-color: #007aff;
+  border-color: var(--color-primary);
   background: white;
   box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.1);
 }
@@ -273,7 +273,7 @@
   height: 44px;
   border: none;
   border-radius: 50%;
-  background: #007aff;
+  background: var(--color-primary);
   color: white;
   font-size: 18px;
   font-weight: bold;
@@ -286,12 +286,12 @@
 }
 
 .send-btn:hover:not(:disabled) {
-  background: #0056cc;
+  background: var(--color-secondary-hover);
   transform: scale(1.05);
 }
 
 .send-btn:disabled {
-  background: #c7c7cc;
+  background: var(--color-border);
   cursor: not-allowed;
   transform: none;
 }
@@ -310,7 +310,7 @@
   height: 60px;
   border: none;
   border-radius: 50%;
-  background: #f2f2f7;
+  background: var(--color-light);
   font-size: 24px;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -321,7 +321,7 @@
 }
 
 .control-btn:hover:not(:disabled) {
-  background: #e5e5ea;
+  background: var(--color-sidebar-hover);
   transform: scale(1.05);
 }
 
@@ -332,32 +332,32 @@
 }
 
 .control-btn.active {
-  background: #007aff;
+  background: var(--color-primary);
   color: white;
-  border-color: #0056cc;
+  border-color: var(--color-secondary-hover);
 }
 
 .control-btn.active:hover {
-  background: #0056cc;
+  background: var(--color-secondary-hover);
 }
 
 /* Specific button styles */
 .connect-btn {
-  background: #34c759;
+  background: var(--color-primary);
   color: white;
 }
 
 .connect-btn:hover {
-  background: #28a745;
+  background: var(--color-secondary-hover);
 }
 
 .disconnect-btn {
-  background: #ff3b30;
+  background: var(--color-secondary);
   color: white;
 }
 
 .disconnect-btn:hover {
-  background: #d70015;
+  background: var(--color-secondary-hover);
 }
 
 /* Voice Selector Container */
@@ -366,12 +366,12 @@
 }
 
 .voice-btn {
-  background: #ff9500;
+  background: var(--color-secondary);
   color: white;
 }
 
 .voice-btn:hover {
-  background: #e6850e;
+  background: var(--color-secondary-hover);
 }
 
 .voice-menu {
@@ -382,7 +382,7 @@
   border-radius: 12px;
   padding: 16px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-  border: 1px solid #e5e5e7;
+  border: 1px solid var(--color-border);
   min-width: 200px;
   z-index: 1000;
   opacity: 0;
@@ -409,14 +409,14 @@
   display: block;
   font-size: 14px;
   font-weight: 600;
-  color: #333;
+  color: var(--color-text);
   margin-bottom: 6px;
 }
 
 .voice-option-group select {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #e5e5e7;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   font-size: 14px;
   background: white;
@@ -425,7 +425,7 @@
 }
 
 .voice-option-group select:focus {
-  border-color: #007aff;
+  border-color: var(--color-primary);
 }
 
 /* Mobile Responsive */
@@ -498,17 +498,17 @@
 }
 
 .messages::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: var(--color-light);
   border-radius: 3px;
 }
 
 .messages::-webkit-scrollbar-thumb {
-  background: #c1c1c1;
+  background: var(--color-border);
   border-radius: 3px;
 }
 
 .messages::-webkit-scrollbar-thumb:hover {
-  background: #a1a1a1;
+  background: var(--color-muted);
 }
 
 /* Touch improvements for mobile */

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -1,15 +1,16 @@
 :root {
-  --color-bg: #f4f4f4;
-  --color-text: #333;
-  --color-muted: #666;
-  --color-primary: #1a73e8;
-  --color-secondary: #5e1f60;
-  --color-secondary-hover: #732c75;
-  --color-light: #f8f9fa;
-  --color-border: #e5e5e7;
-  --color-sidebar-bg: #2c3e50;
-  --color-sidebar-highlight: #e8f0fe;
-  --color-sidebar-hover: #f1f3f4;
+  /* Modern teal + coral color scheme */
+  --color-bg: #fafafa;
+  --color-text: #1f2937;
+  --color-muted: #6b7280;
+  --color-primary: #2a9d8f;
+  --color-secondary: #e76f51;
+  --color-secondary-hover: #d65a3c;
+  --color-light: #ffffff;
+  --color-border: #e5e7eb;
+  --color-sidebar-bg: #264653;
+  --color-sidebar-highlight: #e0f4f1;
+  --color-sidebar-hover: #f0f4f4;
 
   --radius-pill: 24px;
   --radius-md: 8px;
@@ -32,9 +33,9 @@
     --color-bg: #1f2937;
     --color-text: #f9fafb;
     --color-muted: #9ca3af;
-    --color-primary: #60a5fa;
-    --color-secondary: #b747d1;
-    --color-secondary-hover: #a230c0;
+    --color-primary: #2dd4bf;
+    --color-secondary: #fb8450;
+    --color-secondary-hover: #f97316;
     --color-light: #374151;
     --color-border: #374151;
     --color-sidebar-bg: #111827;


### PR DESCRIPTION
## Summary
- modernize design tokens with teal/coral theme
- apply new tokens in AppHeader, AuthWidget, and GeminiLiveDirect

## Testing
- `CI=true npm test --prefix frontend -- -w=0`
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_6846d161a50c8323be49559883a602bf