### PR TITLE
Apply monochrome blue theme

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -342,8 +342,8 @@ body {
 .api-controls input:focus,
 .api-controls select:focus {
   outline: none;
-  border-color: #3498db;
-  box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.2), 0 2px 8px rgba(0, 0, 0, 0.15);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(44, 123, 229, 0.2), 0 2px 8px rgba(0, 0, 0, 0.15);
   transform: translateY(-1px);
 }
 
@@ -362,7 +362,7 @@ body {
   padding: 6px 14px;
   border-radius: 6px;
   border: none;
-  background: linear-gradient(135deg, #3498db 0%, #2980b9 100%);
+  background-color: var(--color-primary);
   color: white;
   cursor: pointer;
   font-size: 12px;
@@ -371,21 +371,21 @@ body {
   min-height: 32px;
   height: 32px;
   white-space: nowrap;
-  box-shadow: 0 2px 6px rgba(52, 152, 219, 0.3);
+  box-shadow: 0 2px 6px rgba(44, 123, 229, 0.3);
   text-transform: uppercase;
   letter-spacing: 0.3px;
 }
 
 .api-controls button.active {
-  background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
-  box-shadow: 0 2px 6px rgba(231, 76, 60, 0.4);
+  background-color: var(--color-primary-dark);
+  box-shadow: 0 2px 6px rgba(26, 86, 194, 0.4);
   animation: pulse 2s infinite;
 }
 
 @keyframes pulse {
-  0% { box-shadow: 0 2px 6px rgba(231, 76, 60, 0.4); }
-  50% { box-shadow: 0 2px 12px rgba(231, 76, 60, 0.6); }
-  100% { box-shadow: 0 2px 6px rgba(231, 76, 60, 0.4); }
+  0% { box-shadow: 0 2px 6px rgba(26, 86, 194, 0.4); }
+  50% { box-shadow: 0 2px 12px rgba(26, 86, 194, 0.6); }
+  100% { box-shadow: 0 2px 6px rgba(26, 86, 194, 0.4); }
 }
 
 @media (max-width: 768px) {
@@ -398,18 +398,18 @@ body {
 }
 
 .api-controls button:hover:not(:disabled) {
-  background: linear-gradient(135deg, #2980b9 0%, #1f5f8b 100%);
+  background-color: var(--color-primary-dark);
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(52, 152, 219, 0.4);
+  box-shadow: 0 4px 12px rgba(44, 123, 229, 0.4);
 }
 
 .api-controls button.active:hover {
-  background: linear-gradient(135deg, #c0392b 0%, #a93226 100%);
-  box-shadow: 0 4px 12px rgba(231, 76, 60, 0.5);
+  background-color: var(--color-primary);
+  box-shadow: 0 4px 12px rgba(44, 123, 229, 0.5);
 }
 
 .api-controls button:disabled {
-  background: linear-gradient(135deg, #95a5a6 0%, #7f8c8d 100%);
+  background-color: var(--color-muted);
   cursor: not-allowed;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   transform: none;
@@ -512,7 +512,7 @@ body {
 }
 
 .message-item.user {
-  background-color: #007bff;
+  background-color: var(--color-primary);
   color: white;
   align-self: flex-end;
   border-bottom-right-radius: 4px;
@@ -579,7 +579,7 @@ body {
 }
 
 .no-active-chat button {
-  background-color: #007bff;
+  background-color: var(--color-primary);
   color: white;
   border: none;
   padding: 12px 24px;
@@ -600,7 +600,7 @@ body {
 }
 
 .no-active-chat button:hover {
-  background-color: #0056b3;
+  background-color: var(--color-primary-dark);
 }
 
 /* Loading states */
@@ -626,10 +626,10 @@ body {
   justify-content: center;
   padding: 10px 15px;
   margin: 10px 0;
-  background-color: #f0f9ff;
-  border: 1px solid #cce5ff;
+  background-color: var(--color-sidebar-highlight);
+  border: 1px solid var(--color-primary-light);
   border-radius: 8px;
-  color: #0c5460;
+  color: var(--color-primary-dark);
   align-self: center;
 }
 
@@ -638,7 +638,7 @@ body {
   height: 20px;
   margin: 0 10px 0 0;
   border-width: 2px;
-  border-top-color: #0c5460;
+  border-top-color: var(--color-primary-dark);
 }
 
 .upload-indicator p {
@@ -769,7 +769,7 @@ body {
   align-items: center;
   gap: 8px;
   padding: 20px;
-  background: linear-gradient(135deg, #ff6b6b, #ee5a24);
+  background-color: var(--color-primary);
   border-radius: 12px;
   color: white;
   min-width: 200px;
@@ -806,7 +806,7 @@ body {
 }
 
 .capture-button {
-  background: linear-gradient(135deg, #4CAF50, #45a049);
+  background-color: var(--color-primary);
   color: white;
   border: none;
   padding: 10px 20px;
@@ -819,27 +819,27 @@ body {
 }
 
 .capture-button:hover {
-  background: linear-gradient(135deg, #45a049, #3d8b40);
+  background-color: var(--color-primary-dark);
   transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(76, 175, 80, 0.3);
+  box-shadow: 0 2px 8px rgba(44, 123, 229, 0.3);
 }
 
 .capture-button.recording {
-  background: linear-gradient(135deg, #f44336, #d32f2f);
+  background-color: var(--color-primary-dark);
   animation: recordingPulse 1s ease-in-out infinite;
 }
 
 @keyframes recordingPulse {
   0%, 100% {
-    box-shadow: 0 2px 8px rgba(244, 67, 54, 0.3);
+    box-shadow: 0 2px 8px rgba(26, 86, 194, 0.3);
   }
   50% {
-    box-shadow: 0 2px 16px rgba(244, 67, 54, 0.6);
+    box-shadow: 0 2px 16px rgba(26, 86, 194, 0.6);
   }
 }
 
 .cancel-button {
-  background: linear-gradient(135deg, #6c757d, #5a6268);
+  background-color: var(--color-muted);
   color: white;
   border: none;
   padding: 10px 20px;
@@ -852,9 +852,9 @@ body {
 }
 
 .cancel-button:hover {
-  background: linear-gradient(135deg, #5a6268, #495057);
+  background-color: var(--color-primary-dark);
   transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(108, 117, 125, 0.3);
+  box-shadow: 0 2px 8px rgba(44, 123, 229, 0.3);
 }
 
 /* RESPONSIVE UTILITIES */
@@ -892,7 +892,7 @@ body {
   width: 16px;
   height: 16px;
   border: 2px solid #f3f3f3;
-  border-top: 2px solid #3498db;
+  border-top: 2px solid var(--color-primary);
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }
@@ -1263,8 +1263,8 @@ body {
 }
 
 .api-controls select.provider-select:hover {
-  border-color: #3498db;
-  box-shadow: 0 2px 6px rgba(52, 152, 219, 0.2);
+  border-color: var(--color-primary);
+  box-shadow: 0 2px 6px rgba(44, 123, 229, 0.2);
 }
 
 .api-controls input.api-key-input {
@@ -1355,9 +1355,9 @@ body {
 .sidebar-select:focus,
 .sidebar-input:focus {
   outline: none;
-  border-color: #3498db;
+  border-color: var(--color-primary);
   background: rgba(255, 255, 255, 0.15);
-  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+  box-shadow: 0 0 0 2px rgba(44, 123, 229, 0.2);
 }
 
 .sidebar-input::placeholder {

--- a/frontend/src/components/InteractionReplay.css
+++ b/frontend/src/components/InteractionReplay.css
@@ -86,7 +86,7 @@
 }
 
 .status-playing {
-  color: #4caf50;
+  color: var(--color-primary);
   font-weight: bold;
 }
 
@@ -115,13 +115,13 @@
 }
 
 .audio-indicator.user-audio {
-  background-color: #e3f2fd;
-  border-left: 4px solid #2196f3;
+  background-color: var(--color-sidebar-highlight);
+  border-left: 4px solid var(--color-primary);
 }
 
 .audio-indicator.api-audio {
-  background-color: #f3e5f5;
-  border-left: 4px solid #9c27b0;
+  background-color: var(--color-sidebar-hover);
+  border-left: 4px solid var(--color-primary-dark);
 }
 
 @keyframes pulse {
@@ -242,21 +242,21 @@
   width: 44px;
   height: 44px;
   font-size: 16px;
-  background: #4caf50;
+  background: var(--color-primary);
   color: white;
 }
 
 .play-btn:hover:not(:disabled) {
-  background: #45a049;
+  background: var(--color-primary-dark);
 }
 
 .stop-btn {
-  background: #f44336;
+  background: var(--color-primary-dark);
   color: white;
 }
 
 .stop-btn:hover:not(:disabled) {
-  background: #da190b;
+  background: var(--color-primary);
 }
 
 .speed-select {
@@ -291,11 +291,11 @@
 .status-text {
   font-size: 14px;
   margin-bottom: 8px;
-  color: #495057;
+  color: var(--color-text);
 }
 
 .regenerate-urls-btn {
-  background: #ff6b35;
+  background: var(--color-primary);
   color: white;
   border: none;
   border-radius: 6px;
@@ -307,7 +307,7 @@
 }
 
 .regenerate-urls-btn:hover:not(:disabled) {
-  background: #e55a2b;
+  background: var(--color-primary-dark);
 }
 
 .regenerate-urls-btn:disabled {
@@ -449,25 +449,25 @@
 }
 
 .conversation-turn.current-turn {
-  background: linear-gradient(135deg, #e3f2fd 0%, #f3e5f5 100%);
-  border-color: #2196f3;
-  box-shadow: 0 2px 8px rgba(33, 150, 243, 0.2);
+  background: linear-gradient(135deg, var(--color-sidebar-highlight) 0%, var(--color-sidebar-hover) 100%);
+  border-color: var(--color-primary);
+  box-shadow: 0 2px 8px rgba(44, 123, 229, 0.2);
 }
 
 .conversation-turn.user_speech {
-  border-left: 4px solid #4caf50;
+  border-left: 4px solid var(--color-primary);
 }
 
 .conversation-turn.api_response {
-  border-left: 4px solid #9c27b0;
+  border-left: 4px solid var(--color-primary-dark);
 }
 
 .conversation-turn.user_text {
-  border-left: 4px solid #2196f3;
+  border-left: 4px solid var(--color-primary);
 }
 
 .conversation-turn.user_action {
-  border-left: 4px solid #ff9800;
+  border-left: 4px solid var(--color-primary-light);
 }
 
 .turn-icon {
@@ -527,24 +527,24 @@
 }
 
 .conversation-turn.user_text .text-content-display {
-  background: #e3f2fd;
-  border-color: #2196f3;
+  background: var(--color-sidebar-highlight);
+  border-color: var(--color-primary);
 }
 
 .conversation-turn.api_response .text-content-display {
-  background: #f3e5f5;
-  border-color: #9c27b0;
+  background: var(--color-sidebar-hover);
+  border-color: var(--color-primary-dark);
 }
 
 .current-status {
-  background: rgba(33, 150, 243, 0.1);
+  background: rgba(44, 123, 229, 0.1);
   border-radius: 6px;
   padding: 8px 12px;
-  border-left: 3px solid #2196f3;
+  border-left: 3px solid var(--color-primary);
 }
 
 .status-indicator {
-  color: #2196f3;
+  color: var(--color-primary);
   font-weight: bold;
   font-size: 12px;
   margin-bottom: 4px;

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -2,14 +2,16 @@
   --color-bg: #f4f4f4;
   --color-text: #333;
   --color-muted: #666;
-  --color-primary: #1a73e8;
-  --color-secondary: #5e1f60;
-  --color-secondary-hover: #732c75;
+  --color-primary: #2c7be5;
+  --color-primary-dark: #1a56c2;
+  --color-primary-light: #5aa8f0;
+  --color-secondary: #1a56c2;
+  --color-secondary-hover: #144aab;
   --color-light: #f8f9fa;
   --color-border: #e5e5e7;
-  --color-sidebar-bg: #2c3e50;
-  --color-sidebar-highlight: #e8f0fe;
-  --color-sidebar-hover: #f1f3f4;
+  --color-sidebar-bg: #23437e;
+  --color-sidebar-highlight: #e8f1fc;
+  --color-sidebar-hover: #edf3fd;
 
   --radius-pill: 24px;
   --radius-md: 8px;
@@ -32,13 +34,15 @@
     --color-bg: #1f2937;
     --color-text: #f9fafb;
     --color-muted: #9ca3af;
-    --color-primary: #60a5fa;
-    --color-secondary: #b747d1;
-    --color-secondary-hover: #a230c0;
+  --color-primary: #5aa8f0;
+  --color-primary-dark: #2c7be5;
+  --color-primary-light: #7fc0f7;
+  --color-secondary: #2c7be5;
+  --color-secondary-hover: #1a56c2;
     --color-light: #374151;
     --color-border: #374151;
     --color-sidebar-bg: #111827;
-    --color-sidebar-highlight: #374151;
-    --color-sidebar-hover: #1f2937;
+    --color-sidebar-highlight: #233657;
+    --color-sidebar-hover: #1b2a44;
   }
 }


### PR DESCRIPTION
## Summary
- revamp design tokens with a unified blue palette
- apply solid-color buttons and status indicators
- simplify gradients and button states

## Testing
- `pytest backend/tests/test_auth_service.py`
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_68474fa251fc8323b88cfcff57647852