### PR TITLE
Add camera flip option to mobile interfaces

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -761,6 +761,31 @@ body {
   max-height: 300px;
   border-radius: 8px;
   background: #000;
+  position: relative;
+}
+
+.flip-camera-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: rgba(255,255,255,0.7);
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .flip-camera-button {
+    width: 36px;
+    height: 36px;
+    font-size: 16px;
+  }
 }
 
 .audio-recording-indicator {

--- a/frontend/src/components/GeminiLiveDirect.css
+++ b/frontend/src/components/GeminiLiveDirect.css
@@ -134,6 +134,24 @@
   height: 100%;
 }
 
+.flip-camera-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 5;
+  width: 40px;
+  height: 40px;
+  font-size: 18px;
+}
+
+@media (max-width: 768px) {
+  .flip-camera-btn {
+    width: 36px;
+    height: 36px;
+    font-size: 16px;
+  }
+}
+
 /* Empty state when no video - use pseudo-element */
 .video-section:not(:has(.video-preview))::before {
   content: "📹 Camera off";


### PR DESCRIPTION
## Summary
- add `cameraFacingMode` state to track which camera to use
- implement `flipCamera` handlers in GeminiLiveDirect and MessageInput
- request camera with facing mode when toggling camera
- overlay flip camera buttons on video previews
- style flip camera buttons

## Testing
- `npm test --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6849f5a9008c8323acd95141fbcb0a38