### PR TITLE
Add Nginx reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ GOOGLE_API_KEY=your_google_key
 
 # Gemini Live API (for direct connection)
 REACT_APP_GEMINI_API_KEY=your_api_key_here
-REACT_APP_API_URL=http://localhost:8080
+REACT_APP_API_URL=http://localhost/api
 
 # Development
 FLASK_ENV=development
@@ -69,7 +69,7 @@ docker-compose up --build
 
 # Access the application
 # Frontend: http://localhost:3000
-# Backend API: http://localhost:8080
+# Backend API (via Nginx reverse proxy): http://localhost/api
 ```
 
 ### 3. Manual Setup (Development)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
     env_file:
       - .env  # Load environment variables from .env file (including REACT_APP_GEMINI_API_KEY)
     environment:
-      - REACT_APP_API_URL=http://localhost:8080/api
-      - REACT_APP_OAUTH_ISSUER=http://localhost:5556
+      - REACT_APP_API_URL=http://localhost/api
+      - REACT_APP_OAUTH_ISSUER=http://localhost/dex
       - REACT_APP_OAUTH_CLIENT_ID=chat-app-dev
     depends_on:
       backend:
@@ -83,6 +83,20 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      frontend:
+        condition: service_started
+      backend:
+        condition: service_started
+      oauth-server:
+        condition: service_started
 
 volumes:
   postgres_data: 

--- a/docs/gcs_url_expiration_fix.md
+++ b/docs/gcs_url_expiration_fix.md
@@ -13,7 +13,7 @@ The InteractionReplay component was failing during media preloading with 502 Bad
 
 ### Example Error Pattern
 ```
-GET http://localhost:8080/api/interaction-logs/media/885 502 (BAD GATEWAY)
+GET http://localhost/api/interaction-logs/media/885 502 (BAD GATEWAY)
 Backend logs: "GCS fetch failed: 400"
 ```
 
@@ -147,13 +147,13 @@ elif gcs_response.status_code in [400, 403]:
 
 ```bash
 # Test individual media endpoint (should work now)
-curl -I http://localhost:8080/api/interaction-logs/media/885
+curl -I http://localhost/api/interaction-logs/media/885
 
 # Test batch regeneration (optional manual trigger)
-curl -X POST http://localhost:8080/api/interaction-logs/regenerate-urls/session_1748616970049_m99k4asnw
+curl -X POST http://localhost/api/interaction-logs/regenerate-urls/session_1748616970049_m99k4asnw
 
 # Check for regeneration header
-curl -I http://localhost:8080/api/interaction-logs/media/889
+curl -I http://localhost/api/interaction-logs/media/889
 # Should show: X-URL-Regenerated: true
 ```
 

--- a/docs/testing/auth_backend.md
+++ b/docs/testing/auth_backend.md
@@ -100,19 +100,20 @@ Success rate: 100.0%
 
 ### Authentication Status
 ```bash
-curl http://localhost:8080/api/auth/status
+# via Nginx reverse proxy
+curl http://localhost/api/auth/status
 # ✅ Returns: {"authenticated": false, "user": null}
 ```
 
 ### OAuth URL Generation
 ```bash
-curl http://localhost:8080/api/auth/login
+curl http://localhost/api/auth/login
 # ✅ Returns valid OAuth authorization URL with PKCE
 ```
 
 ### Dex OAuth Server
 ```bash
-curl http://localhost:5556/dex/.well-known/openid_configuration
+curl http://localhost/dex/.well-known/openid_configuration
 # ✅ Returns OAuth discovery document
 ```
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,51 @@
+user  nginx;
+worker_processes  1;
+
+events { worker_connections 1024; }
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    upstream frontend {
+        server frontend:3000;
+    }
+
+    upstream backend {
+        server backend:5000;
+    }
+
+    upstream oauth {
+        server oauth-server:5556;
+    }
+
+    server {
+        listen 80;
+
+        client_max_body_size 50m;
+
+        location /api/ {
+            proxy_pass http://backend:5000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /dex/ {
+            proxy_pass http://oauth-server:5556;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location / {
+            proxy_pass http://frontend:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add nginx service to proxy frontend, backend and oauth
- update compose file to include nginx and new env vars
- document nginx URLs in README
- refresh auth backend testing docs for new base URL
- adjust GCS URL doc examples for nginx

## Testing
- `pytest tests/test_auth_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d246d38f883238f20cb43a0274ad7